### PR TITLE
Fix: Add _theme and _menu attributes to config.json (fixes #4)

### DIFF
--- a/course/config.json
+++ b/course/config.json
@@ -2,6 +2,8 @@
 	"_defaultLanguage": "en",
 	"_defaultDirection": "ltr",
 	"_questionWeight": 1,
+	"_theme": "adapt-contrib-vanilla",
+	"_menu": "adapt-contrib-boxMenu",
 	"_logging": {
 		"_isEnabled": true,
 		"_level": "debug",


### PR DESCRIPTION
Fix #4 

### Fix
Adds `_theme` and `_menu` attributes to _config.json_. Without these, courses can break when importing into AAT v1.